### PR TITLE
pin dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@theme-ui/color": ">=0.10.0",
     "prism-react-renderer": "^1.2.1",
-    "react-live": "^2.2.3"
+    "react-live": "2.2.3"
   },
   "peerDependencies": {
     "react": "^16.14.0 || ^17.0.2",


### PR DESCRIPTION
As documented [here](https://github.com/FormidableLabs/react-live/issues/265) `react-live@2.3.0` introduced a breaking change when used with `react@17`. Following the solution [here](https://github.com/facebook/docusaurus/pull/5556), this PR pins the dependency `@2.2.3` until this issue is resolved.

I encountered this when using the `LiveCode` component on the `design` site, which had previously been working, but due to pulling in the latest version of `react-live` was now showing this error. This should fix it.